### PR TITLE
Filter additional information by owner

### DIFF
--- a/europass/lib.php
+++ b/europass/lib.php
@@ -1997,7 +1997,7 @@ function get_additional_information($export=false, $lang=null, $userid=null) {
     }
 
     $data = array();
-    $data = get_records_select_array('artefact', "artefacttype=?", array('additionalinfo'));
+    $data = get_records_select_array('artefact', "artefacttype=? AND owner=?", array('additionalinfo', $userid));
     if ($data) {
         // Add translated labels for each additional information
         foreach ($data as $item) {


### PR DESCRIPTION
Hi Gregor,

We found a minor problem when users try to a access their own additional information. They can only see the additional information from the first user who send it.
This patch resolves this issue filtering by owner in get_additional_information function.

Thanks for your plugin, and keep up the good work!.